### PR TITLE
Bugfixes for tcp in flash

### DIFF
--- a/hxnet/protocols/WebSocket.hx
+++ b/hxnet/protocols/WebSocket.hx
@@ -144,8 +144,8 @@ class WebSocket extends hxnet.base.Protocol
 				case Binary(bytes): // binary
 					recvBinary(bytes);
 				case Close: // close
-					loseConnection("close connection");
 					cnx.close();
+					loseConnection("close connection");
 				case Ping: // ping
 					cnx.writeBytes(createFrame(Pong)); // send pong
 				case Pong: // pong

--- a/hxnet/tcp/Client.hx
+++ b/hxnet/tcp/Client.hx
@@ -95,12 +95,7 @@ class Client implements hxnet.interfaces.Client
 			catch (e:Dynamic)
 			{
 				// end of stream
-                if (	Std.is(e, haxe.io.Eof)
-					||	e == haxe.io.Error.Blocked
-#if flash
-					|| Std.is(e, flash.errors.EOFError)
-#end
-				)
+                if (Std.is(e, haxe.io.Eof) || e == haxe.io.Error.Blocked #if flash || Std.is(e, flash.errors.EOFError) #end)
 				{
 					buffer.set(bytesReceived, byte);
 					break;
@@ -152,4 +147,5 @@ class Client implements hxnet.interfaces.Client
 	private var client:Socket;
 	private var readSockets:Array<Socket>;
 	private var buffer:Bytes;
+
 }

--- a/hxnet/tcp/Client.hx
+++ b/hxnet/tcp/Client.hx
@@ -29,19 +29,6 @@ class Client implements hxnet.interfaces.Client
 		{
 			client = new Socket();
 #if flash
-			/*
-			client.addEventListener(flash.events.Event.CONNECT, function( _ ) {
-				trace('connected');
-			});
-
-			client.addEventListener(flash.events.IOErrorEvent.IO_ERROR, function( error ) {
-				trace(error);
-			});
-
-			client.addEventListener(flash.events.SecurityErrorEvent.SECURITY_ERROR, function( error ) {
-				trace(error);
-			});
-			*/
 			client.connect(hostname, port);
 #else
 			if (hostname == null) hostname = Host.localhost();

--- a/hxnet/tcp/Client.hx
+++ b/hxnet/tcp/Client.hx
@@ -29,6 +29,19 @@ class Client implements hxnet.interfaces.Client
 		{
 			client = new Socket();
 #if flash
+			/*
+			client.addEventListener(flash.events.Event.CONNECT, function( _ ) {
+				trace('connected');
+			});
+
+			client.addEventListener(flash.events.IOErrorEvent.IO_ERROR, function( error ) {
+				trace(error);
+			});
+
+			client.addEventListener(flash.events.SecurityErrorEvent.SECURITY_ERROR, function( error ) {
+				trace(error);
+			});
+			*/
 			client.connect(hostname, port);
 #else
 			if (hostname == null) hostname = Host.localhost();
@@ -95,7 +108,12 @@ class Client implements hxnet.interfaces.Client
 			catch (e:Dynamic)
 			{
 				// end of stream
-                if (Std.is(e, haxe.io.Eof) || e == haxe.io.Error.Blocked)
+                if (	Std.is(e, haxe.io.Eof)
+					||	e == haxe.io.Error.Blocked
+#if flash
+					|| Std.is(e, flash.errors.EOFError)
+#end
+				)
 				{
 					buffer.set(bytesReceived, byte);
 					break;
@@ -147,5 +165,4 @@ class Client implements hxnet.interfaces.Client
 	private var client:Socket;
 	private var readSockets:Array<Socket>;
 	private var buffer:Bytes;
-
 }

--- a/hxnet/tcp/Connection.hx
+++ b/hxnet/tcp/Connection.hx
@@ -30,6 +30,8 @@ class Connection implements hxnet.interfaces.Connection
 			{
 				socket.writeByte(bytes.get(i));
 			}
+
+			socket.flush();
 #else
 			// if (writeLength) socket.output.writeInt32(bytes.length);
 			socket.output.writeBytes(bytes, 0, bytes.length);


### PR DESCRIPTION
**tcp/Connection.hx** was missing a socket.flush() after writing to the socket
- http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/Socket.html
- On some operating systems, flush() is called automatically between execution frames, but on other operating systems, such as Windows, the data is never sent unless you call flush() explicitly. To ensure your application behaves reliably across all operating systems, it is a good practice to call the flush() method after writing each message (or related group of data) to the socket.

**tcp/Client.hx** exploded with 'Unhandled IOErrorEvent:. text=Error #2031: Socket Error'

Edit:
**protocols/WebSocket** cnx.close() was called after cnx = null
